### PR TITLE
Setup/linter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npm run check

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,34 @@
+{
+	"$schema": "https://biomejs.dev/schemas/2.3.5/schema.json",
+	"vcs": {
+		"enabled": false,
+		"clientKind": "git",
+		"useIgnoreFile": false
+	},
+	"files": {
+		"ignoreUnknown": false
+	},
+	"formatter": {
+		"enabled": true,
+		"indentStyle": "tab"
+	},
+	"linter": {
+		"enabled": true,
+		"rules": {
+			"recommended": true
+		}
+	},
+	"javascript": {
+		"formatter": {
+			"quoteStyle": "double"
+		}
+	},
+	"assist": {
+		"enabled": true,
+		"actions": {
+			"source": {
+				"organizeImports": "on"
+			}
+		}
+	}
+}

--- a/biome.json
+++ b/biome.json
@@ -1,9 +1,9 @@
 {
 	"$schema": "https://biomejs.dev/schemas/2.3.5/schema.json",
 	"vcs": {
-		"enabled": false,
+		"enabled": true,
 		"clientKind": "git",
-		"useIgnoreFile": false
+		"useIgnoreFile": true
 	},
 	"files": {
 		"ignoreUnknown": false
@@ -15,12 +15,130 @@
 	"linter": {
 		"enabled": true,
 		"rules": {
-			"recommended": true
-		}
-	},
-	"javascript": {
-		"formatter": {
-			"quoteStyle": "double"
+			"recommended": true,
+			"style": {
+				"useNamingConvention": {
+					"level": "error",
+					"options": {
+						"conventions": [
+							{
+								"selector": {
+									"kind": "functionParameter",
+									"scope": "any"
+								},
+								"formats": [
+									"snake_case"
+								]
+							},
+							{
+								"selector": {
+									"kind": "variable",
+									"scope": "any"
+								},
+								"formats": [
+									"snake_case"
+								]
+							},
+							{
+								"selector": {
+									"kind": "const",
+									"scope": "any"
+								},
+								"formats": [
+									"CONSTANT_CASE",
+									"snake_case"
+								]
+							}
+						]
+					}
+				}
+			},
+			"correctness": {
+				"noConstantCondition": "error",
+				"noUnreachable": "error",
+				"noUnsafeOptionalChaining": "error",
+				"noInvalidBuiltinInstantiation": "error",
+				"noUndeclaredDependencies": "error",
+				"noProcessGlobal": "error",
+				"useImportExtensions": "error",
+				"useJsonImportAttributes": "error",
+				"useHookAtTopLevel": "error",
+				"useJsxKeyInIterable": "error",
+				"useIsNan": "error",
+				"useParseIntRadix": "error",
+				"useValidTypeof": "error",
+				"useYield": "error"
+			},
+			"suspicious": {
+				"noDebugger": "error",
+				"noConsole": "error",
+				"noDocumentCookie": "error",
+				"noDuplicateAtImportRules": "error",
+				"noDuplicateCase": "error",
+				"noDuplicateClassMembers": "error",
+				"noDuplicateObjectKeys": "error",
+				"noDuplicateParameters": "error",
+				"noDuplicateProperties": "error",
+				"noEmptyBlock": "error",
+				"noIrregularWhitespace": "error",
+				"noMisleadingCharacterClass": "error",
+				"noMisleadingInstantiator": "error",
+				"noMisplacedAssertion": "error",
+				"noMisrefactoredShorthandAssign": "error",
+				"noPrototypeBuiltins": "error",
+				"noRedeclare": "error",
+				"noRedundantUseStrict": "error",
+				"noSelfCompare": "error",
+				"noShadowRestrictedNames": "error",
+				"noShorthandPropertyOverrides": "error",
+				"noSparseArray": "error",
+				"noTemplateCurlyInString": "error",
+				"noThenProperty": "error",
+				"noUnsafeNegation": "error",
+				"noUselessEscapeInString": "error",
+				"noUselessRegexBackrefs": "error",
+				"noWith": "error",
+				"noVar": "error"
+			},
+			"complexity": {
+				"noExtraBooleanCast": "error",
+				"noImplicitCoercions": "error",
+				"noUselessFragments": "error",
+				"noUselessStringConcat": "error",
+				"noUselessTernary": "error",
+				"noUselessLoneBlockStatements": "error"
+			},
+			"security": {
+				"noSecrets": {
+					"level": "error",
+					"options": {
+						"entropyThreshold": 41
+					}
+				}
+			},
+			"a11y": {
+				"useAltText": "error",
+				"useAnchorContent": "error",
+				"useAriaActivedescendantWithTabindex": "error",
+				"useAriaPropsForRole": "error",
+				"useAriaPropsSupportedByRole": "error",
+				"useButtonType": "error",
+				"useFocusableInteractive": "error",
+				"useGenericFontNames": "error",
+				"useHeadingContent": "error",
+				"useHtmlLang": "error",
+				"useIframeTitle": "error",
+				"useKeyWithClickEvents": "error",
+				"useKeyWithMouseEvents": "error",
+				"useMediaCaption": "error",
+				"useSemanticElements": "error",
+				"useValidAnchor": "error",
+				"useValidAriaProps": "error",
+				"useValidAriaRole": "error",
+				"useValidAriaValues": "error",
+				"useValidAutocomplete": "error",
+				"useValidLang": "error"
+			}
 		}
 	},
 	"assist": {
@@ -29,6 +147,19 @@
 			"source": {
 				"organizeImports": "on"
 			}
+		}
+	},
+	"javascript": {
+		"formatter": {
+			"quoteStyle": "double"
+		}
+	},
+	"html": {
+		"formatter": {
+			"enabled": true
+		},
+		"linter": {
+			"enabled": true
 		}
 	}
 }

--- a/biome.json
+++ b/biome.json
@@ -52,6 +52,7 @@
 				"noUnsafeOptionalChaining": "error",
 				"noInvalidBuiltinInstantiation": "error",
 				"noUndeclaredDependencies": "error",
+				"noUnusedVariables": "error",
 				"noProcessGlobal": "error",
 				"useImportExtensions": "error",
 				"useJsonImportAttributes": "error",

--- a/biome.json
+++ b/biome.json
@@ -26,28 +26,21 @@
 									"kind": "functionParameter",
 									"scope": "any"
 								},
-								"formats": [
-									"snake_case"
-								]
+								"formats": ["snake_case"]
 							},
 							{
 								"selector": {
 									"kind": "variable",
 									"scope": "any"
 								},
-								"formats": [
-									"snake_case"
-								]
+								"formats": ["snake_case"]
 							},
 							{
 								"selector": {
 									"kind": "const",
 									"scope": "any"
 								},
-								"formats": [
-									"CONSTANT_CASE",
-									"snake_case"
-								]
+								"formats": ["CONSTANT_CASE", "snake_case"]
 							}
 						]
 					}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,179 @@
+{
+	"name": "squiz",
+	"version": "1.0.0",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "squiz",
+			"version": "1.0.0",
+			"license": "ISC",
+			"devDependencies": {
+				"@biomejs/biome": "2.3.5"
+			}
+		},
+		"node_modules/@biomejs/biome": {
+			"version": "2.3.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.3.5.tgz",
+			"integrity": "sha512-HvLhNlIlBIbAV77VysRIBEwp55oM/QAjQEin74QQX9Xb259/XP/D5AGGnZMOyF1el4zcvlNYYR3AyTMUV3ILhg==",
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"bin": {
+				"biome": "bin/biome"
+			},
+			"engines": {
+				"node": ">=14.21.3"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/biome"
+			},
+			"optionalDependencies": {
+				"@biomejs/cli-darwin-arm64": "2.3.5",
+				"@biomejs/cli-darwin-x64": "2.3.5",
+				"@biomejs/cli-linux-arm64": "2.3.5",
+				"@biomejs/cli-linux-arm64-musl": "2.3.5",
+				"@biomejs/cli-linux-x64": "2.3.5",
+				"@biomejs/cli-linux-x64-musl": "2.3.5",
+				"@biomejs/cli-win32-arm64": "2.3.5",
+				"@biomejs/cli-win32-x64": "2.3.5"
+			}
+		},
+		"node_modules/@biomejs/cli-darwin-arm64": {
+			"version": "2.3.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.3.5.tgz",
+			"integrity": "sha512-fLdTur8cJU33HxHUUsii3GLx/TR0BsfQx8FkeqIiW33cGMtUD56fAtrh+2Fx1uhiCsVZlFh6iLKUU3pniZREQw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/cli-darwin-x64": {
+			"version": "2.3.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.3.5.tgz",
+			"integrity": "sha512-qpT8XDqeUlzrOW8zb4k3tjhT7rmvVRumhi2657I2aGcY4B+Ft5fNwDdZGACzn8zj7/K1fdWjgwYE3i2mSZ+vOA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/cli-linux-arm64": {
+			"version": "2.3.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.3.5.tgz",
+			"integrity": "sha512-u/pybjTBPGBHB66ku4pK1gj+Dxgx7/+Z0jAriZISPX1ocTO8aHh8x8e7Kb1rB4Ms0nA/SzjtNOVJ4exVavQBCw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/cli-linux-arm64-musl": {
+			"version": "2.3.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.3.5.tgz",
+			"integrity": "sha512-eGUG7+hcLgGnMNl1KHVZUYxahYAhC462jF/wQolqu4qso2MSk32Q+QrpN7eN4jAHAg7FUMIo897muIhK4hXhqg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/cli-linux-x64": {
+			"version": "2.3.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.3.5.tgz",
+			"integrity": "sha512-XrIVi9YAW6ye0CGQ+yax0gLfx+BFOtKaNX74n+xHWla6Cl6huUmcKNO7HPx7BiKnJUzrxXY1qYlm7xMvi08X4g==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/cli-linux-x64-musl": {
+			"version": "2.3.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.3.5.tgz",
+			"integrity": "sha512-awVuycTPpVTH/+WDVnEEYSf6nbCBHf/4wB3lquwT7puhNg8R4XvonWNZzUsfHZrCkjkLhFH/vCZK5jHatD9FEg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/cli-win32-arm64": {
+			"version": "2.3.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.3.5.tgz",
+			"integrity": "sha512-DlBiMlBZZ9eIq4H7RimDSGsYcOtfOIfZOaI5CqsWiSlbTfqbPVfWtCf92wNzx8GNMbu1s7/g3ZZESr6+GwM/SA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/cli-win32-x64": {
+			"version": "2.3.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.3.5.tgz",
+			"integrity": "sha512-nUmR8gb6yvrKhtRgzwo/gDimPwnO5a4sCydf8ZS2kHIJhEmSmk+STsusr1LHTuM//wXppBawvSQi2xFXJCdgKQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		}
+	}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
 			"version": "1.0.0",
 			"license": "ISC",
 			"devDependencies": {
-				"@biomejs/biome": "2.3.5"
+				"@biomejs/biome": "2.3.5",
+				"husky": "^9.1.7"
 			}
 		},
 		"node_modules/@biomejs/biome": {
@@ -173,6 +174,22 @@
 			],
 			"engines": {
 				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/husky": {
+			"version": "9.1.7",
+			"resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+			"integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"husky": "bin.js"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/typicode"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,11 @@
 	"description": "",
 	"main": "index.js",
 	"scripts": {
-		"test": "echo \"Error: no test specified\" && exit 1"
+		"test": "echo \"Error: no test specified\" && exit 1",
+		"prepare": "husky",
+		"lint": "biome lint .",
+		"format": "biome format .",
+		"check": "biome check --no-errors-on-unmatched --files-ignore-unknown=true ."
 	},
 	"repository": {
 		"type": "git",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+	"name": "squiz",
+	"version": "1.0.0",
+	"description": "",
+	"main": "index.js",
+	"scripts": {
+		"test": "echo \"Error: no test specified\" && exit 1"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/tcstenungsund/squiz.git"
+	},
+	"keywords": [],
+	"author": "",
+	"license": "ISC",
+	"type": "commonjs",
+	"bugs": {
+		"url": "https://github.com/tcstenungsund/squiz/issues"
+	},
+	"homepage": "https://github.com/tcstenungsund/squiz#readme"
+}

--- a/package.json
+++ b/package.json
@@ -17,5 +17,8 @@
 	"bugs": {
 		"url": "https://github.com/tcstenungsund/squiz/issues"
 	},
-	"homepage": "https://github.com/tcstenungsund/squiz#readme"
+	"homepage": "https://github.com/tcstenungsund/squiz#readme",
+	"devDependencies": {
+		"@biomejs/biome": "2.3.5"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
 	},
 	"homepage": "https://github.com/tcstenungsund/squiz#readme",
 	"devDependencies": {
-		"@biomejs/biome": "2.3.5"
+		"@biomejs/biome": "2.3.5",
+		"husky": "^9.1.7"
 	}
 }


### PR DESCRIPTION
Set up and configured the [Biome code linter](https://biomejs.dev/) to standardize code formatting across the project.

Added npm scripts for convenience:

    npm run lint
    npm run format
    npm run check

Configured Husky to run Biome before commits, preventing commits that don’t comply with the project’s lint and formatting rules.

Closes #7.